### PR TITLE
Don't crash on volume change

### DIFF
--- a/src/android/de/codevise/cordova/volume/Volume.java
+++ b/src/android/de/codevise/cordova/volume/Volume.java
@@ -91,7 +91,9 @@ public class Volume extends CordovaPlugin {
     private void triggerEvent(CallbackContext callback, double volume, boolean keepCallback) {
         PluginResult result = new PluginResult(PluginResult.Status.OK, (float) currentVolume());
         result.setKeepCallback(keepCallback);
-        callback.sendPluginResult(result);
+        if(callback) {
+            callback.sendPluginResult(result);
+        }
     }
 
 }


### PR DESCRIPTION
If changedEventCallback isn't defined and the user changes the volume, it will trigger an event that will raise an error since it's trying to call "sendPluginResult" on a null reference. This would happen if the app hasn't yet called "window.plugin.volume.getVolume" and a volume event is triggered by the system.
