### PR TITLE
don't error when no listener present on android

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -7,7 +7,7 @@
   <name>Volume</name>
 
   <description>A plugin to query the current device volumen.</description>
-  <repo>https://github.com/g-w/cordova-volume</repo>
+  <repo>https://github.com/whitmer/cordova-volume</repo>
   <keywords>volume,  ios, android</keywords>
   <license>MIT</license>
 

--- a/src/android/de/codevise/cordova/volume/Volume.java
+++ b/src/android/de/codevise/cordova/volume/Volume.java
@@ -89,9 +89,11 @@ public class Volume extends CordovaPlugin {
     }
 
     private void triggerEvent(CallbackContext callback, double volume, boolean keepCallback) {
-        PluginResult result = new PluginResult(PluginResult.Status.OK, (float) currentVolume());
-        result.setKeepCallback(keepCallback);
-        callback.sendPluginResult(result);
+        if(callback != null) {
+            PluginResult result = new PluginResult(PluginResult.Status.OK, (float) currentVolume());
+            result.setKeepCallback(keepCallback);
+            callback.sendPluginResult(result);
+        }
     }
 
 }


### PR DESCRIPTION
On Android, if you don't have a listener assigned, volume change events were crashing the app.
